### PR TITLE
Add autoFocus

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,7 @@ export default class OTPInputView extends Component {
                     onKeyPress={({ nativeEvent: { key } }) => { this._onKeyPress(index, key) }}
                     value={this.state.digits[index]}
                     keyboardType="number-pad"
+                    autoFocus={true}
                     textContentType= {isOTPSupported ? "oneTimeCode" : "none"}
                     key={index}
                     selectionColor="#00000000"


### PR DESCRIPTION
Given that the OTP doesn't automatically focus to the first input , if a user didn't have the keyboard open it could pose a problem.