### PR TITLE
Placeholder Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ const styles = StyleSheet.create({
 | secureTextEntry | NO | Hide contents of text fields |
 | keyboardType | NO | Keyboard type |
 | clearInputs | NO | Clear inputs after entering code |
+| placeholderCharacter | NO | The character/string that will be used as placeholder in the individual code input fields |
+| placeholderTextColor | NO | Color of the placeholderCharacter |
 
 ## Notes
 The iOS input suggestion requires React Native 0.58+ and works for iOS 12 and above. 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ export default class OTPInputView extends Component {
         code: PropTypes.string,
         secureTextEntry: PropTypes.bool,
         keyboardType: PropTypes.string,
-        clearInputs: PropTypes.bool
+        clearInputs: PropTypes.bool,
+        placeholderCharacter: PropTypes.string,
+        placeholderTextColor: PropTypes.string
     }
 
     static defaultProps = {
@@ -26,7 +28,8 @@ export default class OTPInputView extends Component {
         autoFocusOnLoad: true,
         secureTextEntry: false,
         keyboardType: "number-pad",
-        clearInputs: false
+        clearInputs: false,
+        placeholderCharacter: "-"
     }
 
     fields = []
@@ -188,7 +191,7 @@ export default class OTPInputView extends Component {
         const { codeInputFieldStyle, codeInputHighlightStyle, secureTextEntry, keyboardType } = this.props
         const { defaultTextFieldStyle } = styles
         const { selectedIndex, digits } = this.state
-        const { clearInputs } = this.props
+        const { clearInputs, placeholderCharacter, placeholderTextColor } = this.props
         return (
             <View pointerEvents="none" key={index + "view"}>
                 <TextInput
@@ -205,6 +208,8 @@ export default class OTPInputView extends Component {
                     key={index}
                     selectionColor="#00000000"
                     secureTextEntry={secureTextEntry}
+                    placeholder={placeholderCharacter}
+                    placeholderTextColor={placeholderTextColor}
                 />
             </View>
         )


### PR DESCRIPTION
Fixes Twotalltotems/react-native-otp-input#43

The following props are added for to the Component
- `placeholderCharacter` - A string/character that will be displayed as a placeholder in all the otp input fields
- `placeholderTextColor` - color for the placeholder