### PR TITLE
Refactor input placeholder based on DaniAkash's `test placeholder` PR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ const styles = StyleSheet.create({
 | secureTextEntry | NO | Hide contents of text fields |
 | keyboardType | NO | Keyboard type |
 | clearInputs | NO | Clear inputs after entering code |
+| placeholderCharacter | NO | The character/string that will be used as placeholder in the individual code input fields |
+| placeholderTextColor | NO | Color of the placeholderCharacter |
 
 ## Notes
 The iOS input suggestion requires React Native 0.58+ and works for iOS 12 and above. 

--- a/example/App.js
+++ b/example/App.js
@@ -35,6 +35,8 @@ export default class App extends React.Component {
           onCodeFilled = {(code => {
               console.log(`Code is ${code}, you are good to go!`)
           })}
+          // placeholderCharacter={'*'}
+          // placeholderTextColor={'red'}
         />
       </View>
     );

--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ export default class OTPInputView extends Component {
         secureTextEntry: false,
         keyboardType: "number-pad",
         clearInputs: false,
-        placeholderCharacter: "-"
+        placeholderCharacter: "",
+        placeholderTextColor: null,
     }
 
     fields = []
@@ -192,6 +193,7 @@ export default class OTPInputView extends Component {
         const { defaultTextFieldStyle } = styles
         const { selectedIndex, digits } = this.state
         const { clearInputs, placeholderCharacter, placeholderTextColor } = this.props
+        const { color: defaultPlaceholderTextColor } = { ...defaultTextFieldStyle, ...codeInputFieldStyle }
         return (
             <View pointerEvents="none" key={index + "view"}>
                 <TextInput
@@ -209,7 +211,7 @@ export default class OTPInputView extends Component {
                     selectionColor="#00000000"
                     secureTextEntry={secureTextEntry}
                     placeholder={placeholderCharacter}
-                    placeholderTextColor={placeholderTextColor}
+                    placeholderTextColor={placeholderTextColor || defaultPlaceholderTextColor}
                 />
             </View>
         )

--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ export default class OTPInputView extends Component {
         code: PropTypes.string,
         secureTextEntry: PropTypes.bool,
         keyboardType: PropTypes.string,
-        clearInputs: PropTypes.bool
+        clearInputs: PropTypes.bool,
+        placeholderCharacter: PropTypes.string,
+        placeholderTextColor: PropTypes.string
     }
 
     static defaultProps = {
@@ -26,7 +28,8 @@ export default class OTPInputView extends Component {
         autoFocusOnLoad: true,
         secureTextEntry: false,
         keyboardType: "number-pad",
-        clearInputs: false
+        clearInputs: false,
+        placeholderCharacter: "-"
     }
 
     fields = []
@@ -188,7 +191,7 @@ export default class OTPInputView extends Component {
         const { codeInputFieldStyle, codeInputHighlightStyle, secureTextEntry, keyboardType } = this.props
         const { defaultTextFieldStyle } = styles
         const { selectedIndex, digits } = this.state
-        const { clearInputs } = this.props
+        const { clearInputs, placeholderCharacter, placeholderTextColor } = this.props
         return (
             <View pointerEvents="none" key={index + "view"}>
                 <TextInput
@@ -205,6 +208,8 @@ export default class OTPInputView extends Component {
                     key={index}
                     selectionColor="#00000000"
                     secureTextEntry={secureTextEntry}
+                    placeholder={placeholderCharacter}
+                    placeholderTextColor={placeholderTextColor}
                 />
             </View>
         )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twotalltotems/react-native-otp-input",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "is a tiny JS library for one time passcode (OTP). Supports smart input suggestion on iOS and code autofill on Android (it will be filled when you press the copy button on the SMS notification bar)",
   "main": "index.js",
   "directories": {

--- a/styles.js
+++ b/styles.js
@@ -7,6 +7,7 @@ export default styles = StyleSheet.create({
         borderColor : 'rgba(226, 226, 226, 1)', 
         borderWidth : 1,
         borderRadius : 2, 
-        textAlign : 'center'
+        textAlign : 'center',
+        color: 'rgba(226, 226, 226, 1)', 
     },
 })


### PR DESCRIPTION
Based on DaniAkash's PR, refactored the logic to make sure the new feature is backward compatible. By default, hide the input placeholder. If only placeholder character is given, apply the same color with digit inputs. If both placeholder character and color are given, apply the placeholder color to placeholder text and display when input is empty. 